### PR TITLE
Fix broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 _fastwebsockets_ is a fast WebSocket protocol implementation.
 
 Passes the
-Autobahn|TestSuite<sup><a href="https://littledivy.github.io/fastwebsockets/servers/">1</a></sup>
+Autobahn|TestSuite<sup><a href="https://denoland.github.io/fastwebsockets/servers/">1</a></sup>
 and fuzzed with LLVM's libfuzzer.
 
 You can use it as a raw websocket frame parser and deal with spec compliance


### PR DESCRIPTION
The link in the readme to the Autobahn|TestSuite is broken.

This PR changes the url from https://littledivy.github.io/fastwebsockets/servers/ to https://denoland.github.io/fastwebsockets/servers/