### PR TITLE
feat: concrete Err type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "assert2"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +300,7 @@ dependencies = [
 name = "fastwebsockets"
 version = "0.4.2"
 dependencies = [
+ "anyhow",
  "assert2",
  "base64",
  "criterion",
@@ -303,6 +310,7 @@ dependencies = [
  "rustls-pemfile",
  "sha1",
  "simdutf8",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "trybuild",
@@ -1015,6 +1023,26 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.10",
+]
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ base64 = { version = "0.21.0", optional = true }
 sha1 = { version = "0.10.5", optional = true }
 utf-8 = "0.7.5"
 rand = "0.8.4"
+thiserror = "1.0.40"
 
 [features]
 default = ["simd"]
@@ -40,6 +41,7 @@ hyper = { version = "0.14.26", features = ["http1", "server", "client", "tcp"] }
 assert2 = "0.3.4"
 trybuild = "1.0.80"
 criterion = "0.4.0"
+anyhow = "1.0.71"
 
 [[bench]]
 name = "unmask"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use fastwebsockets::{Frame, OpCode, WebSocket};
 
 async fn handle_client(
   mut socket: TcpStream,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(), WebSocketError> {
   handshake(&mut socket).await?;
 
   let mut ws = WebSocket::after_handshake(socket);
@@ -69,10 +69,11 @@ This feature is powered by [hyper](https://docs.rs/hyper).
 ```rust
 use fastwebsockets::upgrade::upgrade;
 use hyper::{Request, Body, Response};
+use anyhow::Result;
 
 async fn server_upgrade(
   mut req: Request<Body>,
-) -> Result<Response<Body>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Response<Body>> {
   let (response, fut) = upgrade::upgrade(&mut req)?;
 
   tokio::spawn(async move {
@@ -93,10 +94,7 @@ use fastwebsockets::WebSocket;
 use hyper::{Request, Body, upgrade::Upgraded, header::{UPGRADE, CONNECTION}};
 use tokio::net::TcpStream;
 use std::future::Future;
-
-// Define a type alias for convenience
-type Result<T> =
-  std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+use anyhow::Result;
 
 async fn connect() -> Result<WebSocket<Upgraded>> {
   let stream = TcpStream::connect("localhost:9001").await?;

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -23,9 +23,7 @@ use hyper::upgrade::Upgraded;
 use hyper::Body;
 use hyper::Request;
 use tokio::net::TcpStream;
-
-type Result<T> =
-  std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+use anyhow::Result;
 
 struct SpawnExecutor;
 

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -14,6 +14,7 @@
 
 use std::future::Future;
 
+use anyhow::Result;
 use fastwebsockets::FragmentCollector;
 use fastwebsockets::Frame;
 use fastwebsockets::OpCode;
@@ -23,7 +24,6 @@ use hyper::upgrade::Upgraded;
 use hyper::Body;
 use hyper::Request;
 use tokio::net::TcpStream;
-use anyhow::Result;
 
 struct SpawnExecutor;
 

--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -14,6 +14,7 @@
 
 use fastwebsockets::upgrade;
 use fastwebsockets::OpCode;
+use fastwebsockets::WebSocketError;
 use hyper::server::conn::Http;
 use hyper::service::service_fn;
 use hyper::Body;
@@ -23,7 +24,7 @@ use tokio::net::TcpListener;
 
 async fn handle_client(
   fut: upgrade::UpgradeFut,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<(), WebSocketError> {
   let mut ws = fastwebsockets::FragmentCollector::new(fut.await?);
 
   loop {
@@ -41,7 +42,7 @@ async fn handle_client(
 }
 async fn server_upgrade(
   mut req: Request<Body>,
-) -> Result<Response<Body>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Response<Body>, WebSocketError> {
   let (response, fut) = upgrade::upgrade(&mut req)?;
 
   tokio::task::spawn(async move {
@@ -54,7 +55,7 @@ async fn server_upgrade(
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() -> Result<(), WebSocketError> {
   let listener = TcpListener::bind("127.0.0.1:8080").await?;
   println!("Server started, listening on {}", "127.0.0.1:8080");
   loop {

--- a/examples/echo_server.rs
+++ b/examples/echo_server.rs
@@ -22,9 +22,7 @@ use hyper::Request;
 use hyper::Response;
 use tokio::net::TcpListener;
 
-async fn handle_client(
-  fut: upgrade::UpgradeFut,
-) -> Result<(), WebSocketError> {
+async fn handle_client(fut: upgrade::UpgradeFut) -> Result<(), WebSocketError> {
   let mut ws = fastwebsockets::FragmentCollector::new(fut.await?);
 
   loop {

--- a/examples/tls_server.rs
+++ b/examples/tls_server.rs
@@ -25,10 +25,11 @@ use tokio_rustls::rustls;
 use tokio_rustls::rustls::Certificate;
 use tokio_rustls::rustls::PrivateKey;
 use tokio_rustls::TlsAcceptor;
+use anyhow::Result;
 
 async fn handle_client(
   fut: upgrade::UpgradeFut,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<()> {
   let mut ws = fut.await?;
   ws.set_writev(false);
   let mut ws = fastwebsockets::FragmentCollector::new(ws);
@@ -49,7 +50,7 @@ async fn handle_client(
 
 async fn server_upgrade(
   mut req: Request<Body>,
-) -> Result<Response<Body>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Response<Body>> {
   let (response, fut) = upgrade::upgrade(&mut req)?;
 
   tokio::spawn(async move {
@@ -62,7 +63,7 @@ async fn server_upgrade(
 }
 
 fn tls_acceptor(
-) -> Result<TlsAcceptor, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<TlsAcceptor> {
   static KEY: &[u8] = include_bytes!("./localhost.key");
   static CERT: &[u8] = include_bytes!("./localhost.crt");
 
@@ -82,7 +83,7 @@ fn tls_acceptor(
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() -> Result<()> {
   let acceptor = tls_acceptor()?;
   let listener = TcpListener::bind("127.0.0.1:8080").await?;
   println!("Server started, listening on {}", "127.0.0.1:8080");

--- a/examples/tls_server.rs
+++ b/examples/tls_server.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use anyhow::Result;
 use fastwebsockets::upgrade;
 use fastwebsockets::OpCode;
 use hyper::server::conn::Http;
@@ -25,11 +26,8 @@ use tokio_rustls::rustls;
 use tokio_rustls::rustls::Certificate;
 use tokio_rustls::rustls::PrivateKey;
 use tokio_rustls::TlsAcceptor;
-use anyhow::Result;
 
-async fn handle_client(
-  fut: upgrade::UpgradeFut,
-) -> Result<()> {
+async fn handle_client(fut: upgrade::UpgradeFut) -> Result<()> {
   let mut ws = fut.await?;
   ws.set_writev(false);
   let mut ws = fastwebsockets::FragmentCollector::new(ws);
@@ -48,9 +46,7 @@ async fn handle_client(
   Ok(())
 }
 
-async fn server_upgrade(
-  mut req: Request<Body>,
-) -> Result<Response<Body>> {
+async fn server_upgrade(mut req: Request<Body>) -> Result<Response<Body>> {
   let (response, fut) = upgrade::upgrade(&mut req)?;
 
   tokio::spawn(async move {
@@ -62,8 +58,7 @@ async fn server_upgrade(
   Ok(response)
 }
 
-fn tls_acceptor(
-) -> Result<TlsAcceptor> {
+fn tls_acceptor() -> Result<TlsAcceptor> {
   static KEY: &[u8] = include_bytes!("./localhost.key");
   static CERT: &[u8] = include_bytes!("./localhost.crt");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,44 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WebSocketError {
+  #[error("Invalid fragment")]
+  InvalidFragment,
+  #[error("Invalid UTF-8")]
+  InvalidUTF8,
+  #[error("Invalid continuation frame")]
+  InvalidContinuationFrame,
+  #[error("Invalid status code")]
+  InvalidStatusCode,
+  #[error("Invalid upgrade header")]
+  InvalidUpgradeHeader,
+  #[error("Invalid connection header")]
+  InvalidConnectionHeader,
+  #[error("Connection is closed")]
+  ConnectionClosed,
+  #[error("Invalid close frame")]
+  InvalidCloseFrame,
+  #[error("Invalid close code")]
+  InvalidCloseCode,
+  #[error("Unexpected EOF")]
+  UnexpectedEOF,
+  #[error("Reserved bits are not zero")]
+  ReservedBitsNotZero,
+  #[error("Control frame must not be fragmented")]
+  ControlFrameFragmented,
+  #[error("Ping frame too large")]
+  PingFrameTooLarge,
+  #[error("Frame too large")]
+  FrameTooLarge,
+  #[error("Sec-Websocket-Version must be 13")]
+  InvalidSecWebsocketVersion,
+  #[error("Invalid value")]
+  InvalidValue,
+  #[error("Sec-WebSocket-Key header is missing")]
+  MissingSecWebSocketKey,
+	#[error(transparent)]
+  IoError(#[from] std::io::Error),
+	#[cfg(feature = "upgrade")]
+	#[error(transparent)]
+  HTTPError(#[from] hyper::Error),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,9 +36,9 @@ pub enum WebSocketError {
   InvalidValue,
   #[error("Sec-WebSocket-Key header is missing")]
   MissingSecWebSocketKey,
-	#[error(transparent)]
+  #[error(transparent)]
   IoError(#[from] std::io::Error),
-	#[cfg(feature = "upgrade")]
-	#[error(transparent)]
+  #[cfg(feature = "upgrade")]
+  #[error(transparent)]
   HTTPError(#[from] hyper::Error),
 }

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -89,9 +89,7 @@ impl<'f, S> FragmentCollector<S> {
   /// Reads a WebSocket frame, collecting fragmented messages until the final frame is received and returns the completed message.
   ///
   /// Text frames payload is guaranteed to be valid UTF-8.
-  pub async fn read_frame(
-    &mut self,
-  ) -> Result<Frame<'f>, WebSocketError>
+  pub async fn read_frame(&mut self) -> Result<Frame<'f>, WebSocketError>
   where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -17,6 +17,8 @@ use tokio::io::AsyncWriteExt;
 
 use core::ops::Deref;
 
+use crate::WebSocketError;
+
 macro_rules! repr_u8 {
     ($(#[$meta:meta])* $vis:vis enum $name:ident {
       $($(#[$vmeta:meta])* $vname:ident $(= $val:expr)?,)*
@@ -26,28 +28,13 @@ macro_rules! repr_u8 {
         $($(#[$vmeta])* $vname $(= $val)?,)*
       }
 
-      #[derive(Debug)]
-      pub enum Error {
-        InvalidValue,
-      }
-
-      impl std::fmt::Display for Error {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-          match self {
-            Error::InvalidValue => write!(f, "invalid value"),
-          }
-        }
-      }
-
-      impl std::error::Error for Error {}
-
       impl core::convert::TryFrom<u8> for $name {
-        type Error = Error;
+        type Error = WebSocketError;
 
         fn try_from(v: u8) -> Result<Self, Self::Error> {
           match v {
             $(x if x == $name::$vname as u8 => Ok($name::$vname),)*
-            _ => Err(Error::InvalidValue),
+            _ => Err(WebSocketError::InvalidValue),
           }
         }
       }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -116,9 +116,7 @@ pub fn generate_key() -> String {
 }
 
 // https://github.com/snapview/tungstenite-rs/blob/314feea3055a93e585882fb769854a912a7e6dae/src/handshake/client.rs#L189
-fn verify(
-  response: &Response<Body>,
-) -> Result<(), WebSocketError> {
+fn verify(response: &Response<Body>) -> Result<(), WebSocketError> {
   if response.status() != StatusCode::SWITCHING_PROTOCOLS {
     return Err(WebSocketError::InvalidStatusCode);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,11 @@
 //! ```
 //! use tokio::net::TcpStream;
 //! use fastwebsockets::{WebSocket, OpCode, Role};
+//! use anyhow::Result;
 //!
 //! async fn handle(
 //!   socket: TcpStream,
-//! ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! ) -> Result<()> {
 //!   let mut ws = WebSocket::after_handshake(socket, Role::Server);
 //!   ws.set_writev(false);
 //!   ws.set_auto_close(true);
@@ -58,10 +59,11 @@
 //! ```
 //! use fastwebsockets::{FragmentCollector, WebSocket, Role};
 //! use tokio::net::TcpStream;
+//! use anyhow::Result;
 //!
 //! async fn handle(
 //!   socket: TcpStream,
-//! ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//! ) -> Result<()> {
 //!   let mut ws = WebSocket::after_handshake(socket, Role::Server);
 //!   let mut ws = FragmentCollector::new(ws);
 //!   let incoming = ws.read_frame().await?;
@@ -83,10 +85,11 @@
 //! ```
 //! use fastwebsockets::upgrade::upgrade;
 //! use hyper::{Request, Body, Response};
+//! use anyhow::Result;
 //!
 //! async fn server_upgrade(
 //!   mut req: Request<Body>,
-//! ) -> Result<Response<Body>, Box<dyn std::error::Error + Send + Sync>> {
+//! ) -> Result<Response<Body>> {
 //!   let (response, fut) = upgrade(&mut req)?;
 //!
 //!   tokio::spawn(async move {
@@ -106,10 +109,7 @@
 //! use hyper::{Request, Body, upgrade::Upgraded, header::{UPGRADE, CONNECTION}};
 //! use tokio::net::TcpStream;
 //! use std::future::Future;
-//!
-//! // Define a type alias for convenience
-//! type Result<T> =
-//!   std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+//! use anyhow::Result;
 //!
 //! async fn connect() -> Result<FragmentCollector<Upgraded>> {
 //!   let stream = TcpStream::connect("localhost:9001").await?;
@@ -148,6 +148,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod close;
+mod error;
 mod fragment;
 mod frame;
 /// Client handshake.
@@ -165,6 +166,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
 pub use crate::close::CloseCode;
+pub use crate::error::WebSocketError;
 pub use crate::fragment::FragmentCollector;
 pub use crate::frame::Frame;
 pub use crate::frame::OpCode;
@@ -211,10 +213,11 @@ impl<'f, S> WebSocket<S> {
   /// ```
   /// use tokio::net::TcpStream;
   /// use fastwebsockets::{WebSocket, OpCode, Role};
+  /// use anyhow::Result;
   ///
   /// async fn handle_client(
   ///   socket: TcpStream,
-  /// ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  /// ) -> Result<()> {
   ///   let mut ws = WebSocket::after_handshake(socket, Role::Server);
   ///   // ...
   ///   Ok(())
@@ -298,10 +301,11 @@ impl<'f, S> WebSocket<S> {
   /// ```
   /// use fastwebsockets::{WebSocket, Frame, OpCode};
   /// use tokio::net::TcpStream;
+  /// use anyhow::Result;
   ///
   /// async fn send(
   ///   ws: &mut WebSocket<TcpStream>
-  /// ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  /// ) -> Result<()> {
   ///   let mut frame = Frame::binary(vec![0x01, 0x02, 0x03].into());
   ///   ws.write_frame(frame).await?;
   ///   Ok(())
@@ -310,7 +314,7 @@ impl<'f, S> WebSocket<S> {
   pub async fn write_frame<'a>(
     &'a mut self,
     mut frame: Frame<'a>,
-  ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+  ) -> Result<(), WebSocketError>
   where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {
@@ -344,10 +348,11 @@ impl<'f, S> WebSocket<S> {
   /// ```
   /// use fastwebsockets::{OpCode, WebSocket, Frame};
   /// use tokio::net::TcpStream;
+  /// use anyhow::Result;
   ///
   /// async fn echo(
   ///   ws: &mut WebSocket<TcpStream>
-  /// ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+  /// ) -> Result<()> {
   ///   let frame = ws.read_frame().await?;
   ///   match frame.opcode {
   ///     OpCode::Text | OpCode::Binary => {
@@ -358,9 +363,7 @@ impl<'f, S> WebSocket<S> {
   ///   Ok(())
   /// }
   /// ```
-  pub async fn read_frame(
-    &mut self,
-  ) -> Result<Frame<'f>, Box<dyn std::error::Error + Send + Sync>>
+  pub async fn read_frame(&mut self) -> Result<Frame<'f>, WebSocketError>
   where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {
@@ -371,7 +374,7 @@ impl<'f, S> WebSocket<S> {
   /// Lifetime requirements for safe recv buffer use are not enforced.
   pub(crate) async fn read_frame_inner(
     &mut self,
-  ) -> Result<Frame<'f>, Box<dyn std::error::Error + Send + Sync>>
+  ) -> Result<Frame<'f>, WebSocketError>
   where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {
@@ -383,31 +386,35 @@ impl<'f, S> WebSocket<S> {
 
       let write_half = &mut self.write_half;
       if write_half.closed && frame.opcode != OpCode::Close {
-        return Err("connection is closed".into());
+        return Err(WebSocketError::ConnectionClosed);
       }
 
       match frame.opcode {
         OpCode::Close if self.auto_close && !write_half.closed => {
           match frame.payload.len() {
             0 => {}
-            1 => return Err("invalid close frame".into()),
+            1 => return Err(WebSocketError::InvalidCloseFrame),
             _ => {
               let code = close::CloseCode::from(u16::from_be_bytes(
                 frame.payload[0..2].try_into().unwrap(),
               ));
 
               #[cfg(feature = "simd")]
-              simdutf8::basic::from_utf8(&frame.payload[2..])?;
+              if simdutf8::basic::from_utf8(&frame.payload[2..]).is_err() {
+                return Err(WebSocketError::InvalidUTF8)
+              };
 
               #[cfg(not(feature = "simd"))]
-              std::str::from_utf8(&frame.payload[2..])?;
+              if std::str::from_utf8(&frame.payload[2..]).is_err() {
+                return Err(WebSocketError::InvalidUTF8)
+              };
 
               if !code.is_allowed() {
                 let _ = self
                   .write_frame(Frame::close(1002, &frame.payload[2..]))
                   .await;
 
-                return Err("invalid close code".into());
+                return Err(WebSocketError::InvalidCloseCode);
               }
             }
           };
@@ -422,7 +429,7 @@ impl<'f, S> WebSocket<S> {
         }
         OpCode::Text => {
           if frame.fin && !frame.is_utf8() {
-            break Err("invalid utf-8".into());
+            break Err(WebSocketError::InvalidUTF8);
           }
 
           break Ok(frame);
@@ -434,7 +441,7 @@ impl<'f, S> WebSocket<S> {
 
   async fn parse_frame_header<'a>(
     &mut self,
-  ) -> Result<Frame<'a>, Box<dyn std::error::Error + Send + Sync>>
+  ) -> Result<Frame<'a>, WebSocketError>
   where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {
@@ -442,7 +449,7 @@ impl<'f, S> WebSocket<S> {
       ($n:expr) => {{
         let n = $n;
         if n == 0 {
-          return Err("unexpected eof".into());
+          return Err(WebSocketError::UnexpectedEOF);
         }
         n
       }};
@@ -468,7 +475,7 @@ impl<'f, S> WebSocket<S> {
     let rsv3 = head[0] & 0b00010000 != 0;
 
     if rsv1 || rsv2 || rsv3 {
-      return Err("reserved bits are not zero".into());
+      return Err(WebSocketError::ReservedBitsNotZero);
     }
 
     let opcode = frame::OpCode::try_from(head[0] & 0b00001111)?;
@@ -507,15 +514,15 @@ impl<'f, S> WebSocket<S> {
     };
 
     if frame::is_control(opcode) && !fin {
-      return Err("control frame must not be fragmented".into());
+      return Err(WebSocketError::ControlFrameFragmented);
     }
 
     if opcode == OpCode::Ping && length > 125 {
-      return Err("Ping frame too large".into());
+      return Err(WebSocketError::PingFrameTooLarge);
     }
 
     if length >= self.max_message_size {
-      return Err("Frame too large".into());
+      return Err(WebSocketError::FrameTooLarge);
     }
 
     let required = 2 + extra + mask.map(|_| 4).unwrap_or(0) + length;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,12 +401,12 @@ impl<'f, S> WebSocket<S> {
 
               #[cfg(feature = "simd")]
               if simdutf8::basic::from_utf8(&frame.payload[2..]).is_err() {
-                return Err(WebSocketError::InvalidUTF8)
+                return Err(WebSocketError::InvalidUTF8);
               };
 
               #[cfg(not(feature = "simd"))]
               if std::str::from_utf8(&frame.payload[2..]).is_err() {
-                return Err(WebSocketError::InvalidUTF8)
+                return Err(WebSocketError::InvalidUTF8);
               };
 
               if !code.is_allowed() {

--- a/tests/ui/01-send-executor.rs
+++ b/tests/ui/01-send-executor.rs
@@ -6,6 +6,7 @@ use hyper::Body;
 use hyper::Request;
 use std::future::Future;
 use tokio::net::TcpStream;
+use anyhow::Result;
 
 struct SpawnExecutor;
 
@@ -21,7 +22,7 @@ where
 
 async fn connect(
   path: &str,
-) -> Result<WebSocket<Upgraded>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<WebSocket<Upgraded>> {
   let stream = TcpStream::connect("localhost:9001").await?;
 
   let req = Request::builder()

--- a/tests/ui/02-!send-executor.rs
+++ b/tests/ui/02-!send-executor.rs
@@ -6,6 +6,7 @@ use hyper::Body;
 use hyper::Request;
 use std::future::Future;
 use tokio::net::TcpStream;
+use anyhow::Result;
 
 struct SpawnLocalExecutor;
 
@@ -21,7 +22,7 @@ where
 
 async fn connect(
   path: &str,
-) -> Result<WebSocket<Upgraded>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<WebSocket<Upgraded>> {
   let stream = TcpStream::connect("localhost:9001").await?;
 
   let req = Request::builder()

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -77,7 +77,7 @@ async fn hyper() {
 
 async fn upgrade_websocket(
   mut request: Request<Body>,
-) -> Result<Response<Body>, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<Response<Body>, fastwebsockets::WebSocketError> {
   assert!(fastwebsockets::upgrade::is_upgrade_request(&request) == true);
 
   let (response, stream) = fastwebsockets::upgrade::upgrade(&mut request)?;


### PR DESCRIPTION
Implements `WebSocketError` using the `thiserror` crate.
Resolves https://github.com/denoland/fastwebsockets/issues/28.