### PR TITLE
Added tls client example, using `rustls::TlsConnector`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "tokio-rustls",
  "trybuild",
  "utf-8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1260,6 +1261,15 @@ checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+dependencies = [
+ "rustls-webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,12 @@ name = "autobahn_client"
 path = "examples/autobahn_client.rs"
 required-features = ["upgrade"]
 
+[[example]]
+name = "tls_client"
+path = "examples/tls_client.rs"
+required-features = ["upgrade"]
+
+
 [dependencies]
 tokio = { version = "1.25.0",  default-features = false, features = ["io-util"] }
 simdutf8 = { version = "0.1.4", optional = true }
@@ -42,6 +48,7 @@ assert2 = "0.3.4"
 trybuild = "1.0.80"
 criterion = "0.4.0"
 anyhow = "1.0.71"
+webpki-roots = "0.23.0"
 
 [[bench]]
 name = "unmask"

--- a/examples/tls_client.rs
+++ b/examples/tls_client.rs
@@ -1,111 +1,111 @@
-use std::{sync::Arc};
 use std::future::Future;
+use std::sync::Arc;
 
-use fastwebsockets::{FragmentCollector, Frame, OpCode};
-use tokio::net::TcpStream;
-use tokio_rustls::{
-    TlsConnector,
-    rustls::{
-        ClientConfig, 
-        OwnedTrustAnchor,
-    }
-};
-use hyper::{
-    Body, Request,
-    header::{CONNECTION, UPGRADE},
-    upgrade::Upgraded,  
-};
 use anyhow::Result;
+use fastwebsockets::FragmentCollector;
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use hyper::header::CONNECTION;
+use hyper::header::UPGRADE;
+use hyper::upgrade::Upgraded;
+use hyper::Body;
+use hyper::Request;
+use tokio::net::TcpStream;
+use tokio_rustls::rustls::ClientConfig;
+use tokio_rustls::rustls::OwnedTrustAnchor;
+use tokio_rustls::TlsConnector;
 
 struct SpawnExecutor;
 
 impl<Fut> hyper::rt::Executor<Fut> for SpawnExecutor
 where
-    Fut: Future + Send + 'static,
-    Fut::Output: Send + 'static,
+  Fut: Future + Send + 'static,
+  Fut::Output: Send + 'static,
 {
-    fn execute(&self, fut: Fut) {
-        tokio::task::spawn(fut);
-    }
+  fn execute(&self, fut: Fut) {
+    tokio::task::spawn(fut);
+  }
 }
 
 fn tls_connector() -> Result<TlsConnector> {
+  let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
 
-    let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
+  root_store.add_server_trust_anchors(
+    webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+      OwnedTrustAnchor::from_subject_spki_name_constraints(
+        ta.subject,
+        ta.spki,
+        ta.name_constraints,
+      )
+    }),
+  );
 
-    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(
-        |ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki, 
-                ta.name_constraints)
-        }
-    ));
-
-    let config = ClientConfig::builder()
+  let config = ClientConfig::builder()
     .with_safe_defaults()
     .with_root_certificates(root_store)
     .with_no_client_auth();
 
-    Ok(TlsConnector::from(Arc::new(config)))
+  Ok(TlsConnector::from(Arc::new(config)))
 }
 
 async fn connect(domain: &str) -> Result<FragmentCollector<Upgraded>> {
+  let mut addr = String::from(domain);
+  addr.push_str(":9443"); // Port number for binance stream
 
-    let mut addr = String::from(domain);
-    addr.push_str(":9443"); // Port number for binance stream
+  let tcp_stream = TcpStream::connect(&addr).await?;
+  let tls_connector = tls_connector().unwrap();
+  let domain =
+    tokio_rustls::rustls::ServerName::try_from(domain).map_err(|_| {
+      std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid dnsname")
+    })?;
 
-    let tcp_stream = TcpStream::connect(&addr).await?;
-    let tls_connector = tls_connector().unwrap();
-    let domain = tokio_rustls::rustls::ServerName::try_from(domain)
-    .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid dnsname"))?;
+  let tls_stream = tls_connector.connect(domain, tcp_stream).await?;
 
-    let tls_stream = tls_connector.connect(domain, tcp_stream).await?;
-
-    let req = Request::builder()
+  let req = Request::builder()
     .method("GET")
     .uri(format!("wss://{}/ws/btcusdt@bookTicker", &addr)) //stream we want to subscribe to
     .header("Host", &addr)
     .header(UPGRADE, "websocket")
     .header(CONNECTION, "upgrade")
     .header(
-        "Sec-WebSocket-Key",
-        fastwebsockets::handshake::generate_key(),
+      "Sec-WebSocket-Key",
+      fastwebsockets::handshake::generate_key(),
     )
     .header("Sec-WebSocket-Version", "13")
     .body(Body::empty())?;
 
-    let (ws, _) = fastwebsockets::handshake::client(&SpawnExecutor, req, tls_stream).await?;
-    Ok(FragmentCollector::new(ws))
-
+  let (ws, _) =
+    fastwebsockets::handshake::client(&SpawnExecutor, req, tls_stream).await?;
+  Ok(FragmentCollector::new(ws))
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    let domain =  "stream.binance.com";
-    let mut ws = connect(domain).await?;
+  let domain = "stream.binance.com";
+  let mut ws = connect(domain).await?;
 
-    loop {
-        let msg = match ws.read_frame().await {
-            Ok(msg) => msg,
-            Err(e) => {
-                println!("Error: {}", e);
-                ws.write_frame(Frame::close_raw(vec![].into())).await?;
-                break;
-            }
-        };
+  loop {
+    let msg = match ws.read_frame().await {
+      Ok(msg) => msg,
+      Err(e) => {
+        println!("Error: {}", e);
+        ws.write_frame(Frame::close_raw(vec![].into())).await?;
+        break;
+      }
+    };
 
-        match msg.opcode {
-            OpCode::Text => {
-                let payload = String::from_utf8(msg.payload.to_vec()).expect("Invalid UTF-8 data");
-                // Normally deserialise from json here, print just to show it works
-                println!("{:?}", payload);
-            }
-            OpCode::Close => {
-                break;
-            }
-            _ => {}
-        }
+    match msg.opcode {
+      OpCode::Text => {
+        let payload =
+          String::from_utf8(msg.payload.to_vec()).expect("Invalid UTF-8 data");
+        // Normally deserialise from json here, print just to show it works
+        println!("{:?}", payload);
+      }
+      OpCode::Close => {
+        break;
+      }
+      _ => {}
     }
-    Ok(())
+  }
+  Ok(())
 }

--- a/examples/tls_client.rs
+++ b/examples/tls_client.rs
@@ -1,0 +1,111 @@
+use std::{sync::Arc};
+use std::future::Future;
+
+use fastwebsockets::{FragmentCollector, Frame, OpCode};
+use tokio::net::TcpStream;
+use tokio_rustls::{
+    TlsConnector,
+    rustls::{
+        ClientConfig, 
+        OwnedTrustAnchor,
+    }
+};
+use hyper::{
+    Body, Request,
+    header::{CONNECTION, UPGRADE},
+    upgrade::Upgraded,  
+};
+use anyhow::Result;
+
+struct SpawnExecutor;
+
+impl<Fut> hyper::rt::Executor<Fut> for SpawnExecutor
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    fn execute(&self, fut: Fut) {
+        tokio::task::spawn(fut);
+    }
+}
+
+fn tls_connector() -> Result<TlsConnector> {
+
+    let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
+
+    root_store.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(
+        |ta| {
+            OwnedTrustAnchor::from_subject_spki_name_constraints(
+                ta.subject,
+                ta.spki, 
+                ta.name_constraints)
+        }
+    ));
+
+    let config = ClientConfig::builder()
+    .with_safe_defaults()
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+
+    Ok(TlsConnector::from(Arc::new(config)))
+}
+
+async fn connect(domain: &str) -> Result<FragmentCollector<Upgraded>> {
+
+    let mut addr = String::from(domain);
+    addr.push_str(":9443"); // Port number for binance stream
+
+    let tcp_stream = TcpStream::connect(&addr).await?;
+    let tls_connector = tls_connector().unwrap();
+    let domain = tokio_rustls::rustls::ServerName::try_from(domain)
+    .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid dnsname"))?;
+
+    let tls_stream = tls_connector.connect(domain, tcp_stream).await?;
+
+    let req = Request::builder()
+    .method("GET")
+    .uri(format!("wss://{}/ws/btcusdt@bookTicker", &addr)) //stream we want to subscribe to
+    .header("Host", &addr)
+    .header(UPGRADE, "websocket")
+    .header(CONNECTION, "upgrade")
+    .header(
+        "Sec-WebSocket-Key",
+        fastwebsockets::handshake::generate_key(),
+    )
+    .header("Sec-WebSocket-Version", "13")
+    .body(Body::empty())?;
+
+    let (ws, _) = fastwebsockets::handshake::client(&SpawnExecutor, req, tls_stream).await?;
+    Ok(FragmentCollector::new(ws))
+
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let domain =  "stream.binance.com";
+    let mut ws = connect(domain).await?;
+
+    loop {
+        let msg = match ws.read_frame().await {
+            Ok(msg) => msg,
+            Err(e) => {
+                println!("Error: {}", e);
+                ws.write_frame(Frame::close_raw(vec![].into())).await?;
+                break;
+            }
+        };
+
+        match msg.opcode {
+            OpCode::Text => {
+                let payload = String::from_utf8(msg.payload.to_vec()).expect("Invalid UTF-8 data");
+                // Normally deserialise from json here, print just to show it works
+                println!("{:?}", payload);
+            }
+            OpCode::Close => {
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
A client which connects to secure websockets, using `rustls::TlsConnector`. Solves #35 and, I think #36. Couldn't convert the local certificate into `rustls::OwnedTrustAnchor`, instead uses the crate `webpki_roots`.