### PR TITLE
feat: refactor to allow for split mode of operation

### DIFF
--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -160,7 +160,7 @@ impl Fragments {
             true,
             frame.opcode,
             None,
-            frame.payload.into(),
+            frame.payload,
           )));
         } else {
           self.fragments = match frame.opcode {

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -74,6 +74,8 @@ pub struct FragmentCollector<S> {
   read_half: ReadHalf,
   write_half: WriteHalf,
   fragments: Fragments,
+  // !Sync marker
+  _marker: std::marker::PhantomData<SharedRecv>,
 }
 
 impl<'f, S> FragmentCollector<S> {

--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -14,6 +14,7 @@
 
 use crate::error::WebSocketError;
 use crate::frame::Frame;
+use crate::recv::SharedRecv;
 use crate::OpCode;
 use crate::ReadHalf;
 use crate::WebSocket;
@@ -90,6 +91,7 @@ impl<'f, S> FragmentCollector<S> {
       read_half,
       write_half,
       fragments: Fragments::new(),
+      _marker: std::marker::PhantomData,
     }
   }
 
@@ -158,12 +160,7 @@ impl Fragments {
           if self.fragments.is_some() {
             return Err(WebSocketError::InvalidFragment);
           }
-          return Ok(Some(Frame::new(
-            true,
-            frame.opcode,
-            None,
-            frame.payload,
-          )));
+          return Ok(Some(Frame::new(true, frame.opcode, None, frame.payload)));
         } else {
           self.fragments = match frame.opcode {
             OpCode::Text => match utf8::decode(&frame.payload) {

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
 use core::ops::Deref;
@@ -285,7 +284,7 @@ impl<'f> Frame<'f> {
     stream: &mut S,
   ) -> Result<(), std::io::Error>
   where
-    S: AsyncReadExt + AsyncWriteExt + Unpin,
+    S: AsyncWriteExt + Unpin,
   {
     use std::io::IoSlice;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,7 +400,7 @@ impl ReadHalf {
     stream: &mut S,
   ) -> (Result<Option<Frame<'f>>, WebSocketError>, Option<Frame<'f>>)
   where
-    S: AsyncReadExt + AsyncWriteExt + Unpin,
+    S: AsyncReadExt + Unpin,
   {
     let mut frame = match self.parse_frame_header(stream).await {
       Ok(frame) => frame,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,31 +174,36 @@ pub use crate::frame::Payload;
 pub use crate::mask::unmask;
 use crate::recv::SharedRecv;
 
-#[derive(PartialEq)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Role {
   Server,
   Client,
 }
 
-struct WriteHalf {
+pub(crate) struct WriteHalf {
+  role: Role,
   closed: bool,
+  vectored: bool,
+  auto_apply_mask: bool,
+  writev_threshold: usize,
   write_buffer: Vec<u8>,
+}
+
+pub(crate) struct ReadHalf {
+  role: Role,
+  spill: Option<Vec<u8>>,
+  auto_apply_mask: bool,
+  auto_close: bool,
+  auto_pong: bool,
+  writev_threshold: usize,
+  max_message_size: usize,
 }
 
 /// WebSocket protocol implementation over an async stream.
 pub struct WebSocket<S> {
   stream: S,
   write_half: WriteHalf,
-  // Config
-  vectored: bool,
-  auto_close: bool,
-  auto_pong: bool,
-  max_message_size: usize,
-  writev_threshold: usize,
-  auto_apply_mask: bool,
-  role: Role,
-  // Read-half
-  spill: Option<Vec<u8>>,
+  read_half: ReadHalf,
   // !Sync marker
   _marker: std::marker::PhantomData<SharedRecv>,
 }
@@ -231,23 +236,24 @@ impl<'f, S> WebSocket<S> {
     Self {
       stream,
       write_half: WriteHalf {
+        role,
         closed: false,
+        auto_apply_mask: true,
+        vectored: true,
+        writev_threshold: 1024,
         write_buffer: Vec::with_capacity(2),
       },
-      vectored: true,
-      auto_close: true,
-      auto_pong: true,
-      auto_apply_mask: true,
-      max_message_size: 64 << 20,
-      writev_threshold: 1024,
-      role,
-      spill: None,
+      read_half: ReadHalf {
+        role,
+        spill: None,
+        auto_apply_mask: true,
+        auto_close: true,
+        auto_pong: true,
+        writev_threshold: 1024,
+        max_message_size: 64 << 20,
+      },
       _marker: std::marker::PhantomData,
     }
-  }
-
-  pub(crate) fn is_write_half_closed(&self) -> bool {
-    self.write_half.closed
   }
 
   /// Consumes the `WebSocket` and returns the underlying stream.
@@ -257,88 +263,51 @@ impl<'f, S> WebSocket<S> {
     self.stream
   }
 
+  /// Consumes the `WebSocket` and returns the underlying stream.
+  #[inline]
+  pub(crate) fn into_parts_internal(self) -> (S, ReadHalf, WriteHalf) {
+    (self.stream, self.read_half, self.write_half)
+  }
+
   /// Sets whether to use vectored writes. This option does not guarantee that vectored writes will be always used.
   ///
   /// Default: `true`
   pub fn set_writev(&mut self, vectored: bool) {
-    self.vectored = vectored;
+    self.write_half.vectored = vectored;
   }
 
   pub fn set_writev_threshold(&mut self, threshold: usize) {
-    self.writev_threshold = threshold;
+    self.read_half.writev_threshold = threshold;
+    self.write_half.writev_threshold = threshold;
   }
 
   /// Sets whether to automatically close the connection when a close frame is received. When set to `false`, the application will have to manually send close frames.
   ///
   /// Default: `true`
   pub fn set_auto_close(&mut self, auto_close: bool) {
-    self.auto_close = auto_close;
+    self.read_half.auto_close = auto_close;
   }
 
   /// Sets whether to automatically send a pong frame when a ping frame is received.
   ///
   /// Default: `true`
   pub fn set_auto_pong(&mut self, auto_pong: bool) {
-    self.auto_pong = auto_pong;
+    self.read_half.auto_pong = auto_pong;
   }
 
   /// Sets the maximum message size in bytes. If a message is received that is larger than this, the connection will be closed.
   ///
   /// Default: 64 MiB
   pub fn set_max_message_size(&mut self, max_message_size: usize) {
-    self.max_message_size = max_message_size;
+    self.read_half.max_message_size = max_message_size;
   }
 
   /// Sets whether to automatically apply the mask to the frame payload.
   ///
   /// Default: `true`
   pub fn set_auto_apply_mask(&mut self, auto_apply_mask: bool) {
-    self.auto_apply_mask = auto_apply_mask;
-  }
-
-  /// Writes a frame to the stream.
-  ///
-  /// This method will not mask the frame payload.
-  ///
-  /// # Example
-  ///
-  /// ```
-  /// use fastwebsockets::{WebSocket, Frame, OpCode};
-  /// use tokio::net::TcpStream;
-  /// use anyhow::Result;
-  ///
-  /// async fn send(
-  ///   ws: &mut WebSocket<TcpStream>
-  /// ) -> Result<()> {
-  ///   let mut frame = Frame::binary(vec![0x01, 0x02, 0x03].into());
-  ///   ws.write_frame(frame).await?;
-  ///   Ok(())
-  /// }
-  /// ```
-  pub async fn write_frame<'a>(
-    &'a mut self,
-    mut frame: Frame<'a>,
-  ) -> Result<(), WebSocketError>
-  where
-    S: AsyncReadExt + AsyncWriteExt + Unpin,
-  {
-    if self.role == Role::Client && self.auto_apply_mask {
-      frame.mask();
-    }
-
-    let write_half = &mut self.write_half;
-    if frame.opcode == OpCode::Close {
-      write_half.closed = true;
-    }
-
-    if self.vectored && frame.payload.len() > self.writev_threshold {
-      frame.writev(&mut self.stream).await?;
-    } else {
-      let text = frame.write(&mut write_half.write_buffer);
-      self.stream.write_all(text).await?;
-    }
-
-    Ok(())
+    self.read_half.auto_apply_mask = auto_apply_mask;
+    self.write_half.auto_apply_mask = auto_apply_mask;
   }
 
   /// Reads a frame from the stream.
@@ -372,11 +341,12 @@ impl<'f, S> WebSocket<S> {
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {
     loop {
-      let (res, obligated_send) = self.read_frame_inner().await;
+      let (res, obligated_send) =
+        self.read_half.read_frame_inner(&mut self.stream).await;
       let is_closed = self.write_half.closed;
       if let Some(frame) = obligated_send {
         if !is_closed {
-          self.write_frame(frame).await?;
+          self.write_half.write_frame(&mut self.stream, frame).await?;
         }
       }
       if let Some(frame) = res? {
@@ -388,6 +358,36 @@ impl<'f, S> WebSocket<S> {
     }
   }
 
+  /// Writes a frame to the stream.
+  ///
+  /// # Example
+  ///
+  /// ```
+  /// use fastwebsockets::{WebSocket, Frame, OpCode};
+  /// use tokio::net::TcpStream;
+  /// use anyhow::Result;
+  ///
+  /// async fn send(
+  ///   ws: &mut WebSocket<TcpStream>
+  /// ) -> Result<()> {
+  ///   let mut frame = Frame::binary(vec![0x01, 0x02, 0x03].into());
+  ///   ws.write_frame(frame).await?;
+  ///   Ok(())
+  /// }
+  /// ```
+  pub async fn write_frame(
+    &mut self,
+    frame: Frame<'f>,
+  ) -> Result<(), WebSocketError>
+  where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+  {
+    self.write_half.write_frame(&mut self.stream, frame).await?;
+    Ok(())
+  }
+}
+
+impl ReadHalf {
   /// Attempt to read a single frame from from the incoming stream, returning any send obligations if
   /// `auto_close` or `auto_pong` are enabled. Callers to this function are obligated to send the
   /// frame in the latter half of the tuple if one is specified, unless the write half of this socket
@@ -395,13 +395,14 @@ impl<'f, S> WebSocket<S> {
   ///
   /// XXX: Do not expose this method to the public API.
   /// Lifetime requirements for safe recv buffer use are not enforced.
-  pub(crate) async fn read_frame_inner(
+  pub(crate) async fn read_frame_inner<'f, S>(
     &mut self,
+    stream: &mut S,
   ) -> (Result<Option<Frame<'f>>, WebSocketError>, Option<Frame<'f>>)
   where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
   {
-    let mut frame = match self.parse_frame_header().await {
+    let mut frame = match self.parse_frame_header(stream).await {
       Ok(frame) => frame,
       Err(e) => return (Err(e), None),
     };
@@ -456,11 +457,12 @@ impl<'f, S> WebSocket<S> {
     }
   }
 
-  async fn parse_frame_header<'a>(
+  async fn parse_frame_header<'a, S>(
     &mut self,
+    stream: &mut S,
   ) -> Result<Frame<'a>, WebSocketError>
   where
-    S: AsyncReadExt + AsyncWriteExt + Unpin,
+    S: AsyncReadExt + Unpin,
   {
     macro_rules! eof {
       ($n:expr) => {{
@@ -472,7 +474,6 @@ impl<'f, S> WebSocket<S> {
       }};
     }
 
-    let stream = &mut self.stream;
     let head = recv::init_once();
     let mut nread = 0;
 
@@ -568,6 +569,34 @@ impl<'f, S> WebSocket<S> {
     };
     let frame = Frame::new(fin, opcode, mask, payload);
     Ok(frame)
+  }
+}
+
+impl WriteHalf {
+  pub async fn write_frame<'a, S>(
+    &'a mut self,
+    stream: &mut S,
+    mut frame: Frame<'a>,
+  ) -> Result<(), WebSocketError>
+  where
+    S: AsyncWriteExt + Unpin,
+  {
+    if self.role == Role::Client && self.auto_apply_mask {
+      frame.mask();
+    }
+
+    if frame.opcode == OpCode::Close {
+      self.closed = true;
+    }
+
+    if self.vectored && frame.payload.len() > self.writev_threshold {
+      frame.writev(stream).await?;
+    } else {
+      let text = frame.write(&mut self.write_buffer);
+      stream.write_all(text).await?;
+    }
+
+    Ok(())
   }
 }
 


### PR DESCRIPTION
Works towards solving #40, allowing read and write halves to work independently. Maintains the old API for compatibility.

This is a pre-factoring PR that splits out a `ReadHalf` and `WriteHalf`, and ensures that you can read and write independently. A later PR will build on this to create the split API.

The main parts of this PR are:

 - A new `Fragments` struct that collects `Frame`s.
 - The split `ReadHalf` and `WriteHalf` that do not contain a stream, allowing us to drive reads and writes externally
 - Reads provide an 'obligated write' which the caller is required to send
 
I tried to avoid making any major logic changes to functions -- this is mainly moving things around for a later patch.

Also note that the logic around checking whether the `WriteHalf` is closed or not has been hoisted into the `read` callers. This is a little awkward given that there is a fragmented and non-fragmented read path that duplicate this logic, but we may be able to clean this up in the future.
