### PR TITLE
axum: fix panic caused by missing upgrade header; HTTP 400 on error

### DIFF
--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -76,26 +76,29 @@ impl<S> axum_core::extract::FromRequestParts<S> for IncomingUpgrade
 where
   S: Sync,
 {
-  type Rejection = ();
+  type Rejection = hyper::StatusCode;
 
   async fn from_request_parts(
     parts: &mut http::request::Parts,
     _state: &S,
   ) -> Result<Self, Self::Rejection> {
-    let key = parts.headers.get("Sec-WebSocket-Key").ok_or(())?;
+    let key = parts
+      .headers
+      .get("Sec-WebSocket-Key")
+      .ok_or(hyper::StatusCode::BAD_REQUEST)?;
     if parts
       .headers
       .get("Sec-WebSocket-Version")
       .map(|v| v.as_bytes())
       != Some(b"13")
     {
-      return Err(());
+      return Err(hyper::StatusCode::BAD_REQUEST);
     }
 
     let on_upgrade = parts
       .extensions
       .remove::<hyper::upgrade::OnUpgrade>()
-      .unwrap();
+      .ok_or(hyper::StatusCode::BAD_REQUEST)?;
     Ok(Self {
       on_upgrade,
       key: sec_websocket_protocol(key.as_bytes()),


### PR DESCRIPTION
Previously, this would lead to a panic:
```console
curl 'http://127.0.0.1:3000' -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: hi' -i
```
```console
❯ cargo run --example axum -F upgrade -F with_axum
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/examples/axum`
thread 'tokio-runtime-worker' panicked at /Users/valentin/Programmieren/fastwebsockets/src/upgrade.rs:98:8:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Additionally, the implementation of `FromRequestParts` for `IncomingUpgrade` now responds to errors with HTTP status `400` instead of `200`.