### PR TITLE
Add FragmentCollector::into_inner

### DIFF
--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -135,6 +135,12 @@ impl<'f, S> FragmentCollector<S> {
     self.write_half.write_frame(&mut self.stream, frame).await?;
     Ok(())
   }
+
+  /// Consumes the `FragmentCollector` and returns the underlying stream.
+  #[inline]
+  pub fn into_inner(self) -> S {
+    self.stream
+  }
 }
 
 #[cfg(feature = "unstable-split")]


### PR DESCRIPTION
It would be useful to have this method so that the underlying stream can be closed, similar to the `Websocket` type.