### PR TITLE
fix: Use correct `AsyncRead` bound in `after_handshake_split`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ pub fn after_handshake_split<R, W>(
   role: Role,
 ) -> (WebSocketRead<R>, WebSocketWrite<W>)
 where
-  R: AsyncWrite + Unpin,
+  R: AsyncRead + Unpin,
   W: AsyncWrite + Unpin,
 {
   (


### PR DESCRIPTION
Noticed that I can't pass my read stream into `after_handshake_split`, because it's not `AsyncWrite`. However, that bound is just incorrect and should be `AsyncRead`, a copy-and-paste error I assume.

Ran `cargo test --all-features` locally and it went through fine.