### PR TITLE
perf: use plain iterator for payload unmasking

### DIFF
--- a/src/mask.rs
+++ b/src/mask.rs
@@ -14,9 +14,9 @@
 
 #[inline]
 fn unmask_easy(payload: &mut [u8], mask: [u8; 4]) {
-  for i in 0..payload.len() {
-    payload[i] ^= mask[i & 3];
-  }
+  payload.iter_mut().enumerate().for_each(|(i, v)| {
+    *v ^= mask[i & 3];
+  });
 }
 
 // TODO(@littledivy): Compiler does a good job at auto-vectorizing `unmask_fallback` with


### PR DESCRIPTION
This tweaks `unmask_easy` logic in order to directly use an enumerating iterator. It allows the compiler to generate more optimal machine code by performing internal iteration directly on the input slice.