### PR TITLE
fix: remove deprecated method & append missing features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,30 @@ path = "examples/tls_client.rs"
 required-features = ["upgrade"]
 
 [[example]]
+name = "tls_server"
+path = "examples/tls_server.rs"
+required-features = ["upgrade"]
+
+[[example]]
 name = "axum"
 path = "examples/axum.rs"
 required-features = ["upgrade", "with_axum"]
 
+[[example]]
+name = "echo_server_split"
+path = "examples/echo_server_split.rs"
+required-features = ["upgrade"]
+
 [dependencies]
-tokio = { version = "1.25.0",  default-features = false, features = ["io-util"] }
+tokio = { version = "1.25.0", default-features = false, features = ["io-util"] }
 simdutf8 = { version = "0.1.4", optional = true }
 hyper-util = { version = "0.1.0", features = ["tokio"], optional = true }
 http-body-util = { version = "0.1.0", optional = true }
-hyper = { version = "1", features = ["http1", "server", "client"], optional = true }
+hyper = { version = "1", features = [
+    "http1",
+    "server",
+    "client",
+], optional = true }
 pin-project = { version = "1.0.8", optional = true }
 base64 = { version = "0.21.0", optional = true }
 sha1 = { version = "0.10.5", optional = true }
@@ -49,7 +63,14 @@ async-trait = { version = "0.1", optional = true }
 [features]
 default = ["simd"]
 simd = ["simdutf8/aarch64_neon"]
-upgrade = ["hyper", "pin-project", "base64", "sha1", "hyper-util", "http-body-util"]
+upgrade = [
+    "hyper",
+    "pin-project",
+    "base64",
+    "sha1",
+    "hyper-util",
+    "http-body-util",
+]
 unstable-split = []
 # Axum integration
 with_axum = ["axum-core", "http", "async-trait"]
@@ -68,6 +89,21 @@ anyhow = "1.0.71"
 webpki-roots = "0.23.0"
 bytes = "1.4.0"
 axum = "0.7.4"
+
+[[test]]
+name = "upgrade"
+path = "tests/upgrade.rs"
+required-features = ["upgrade"]
+
+[[test]]
+name = "split"
+path = "tests/split.rs"
+required-features = ["upgrade"]
+
+[[test]]
+name = "concurrency"
+path = "tests/concurrency.rs"
+required-features = ["upgrade"]
 
 [[bench]]
 name = "unmask"

--- a/examples/tls_client.rs
+++ b/examples/tls_client.rs
@@ -32,15 +32,15 @@ where
 fn tls_connector() -> Result<TlsConnector> {
   let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
 
-  root_store.add_server_trust_anchors(
-    webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+  root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(
+    |ta| {
       OwnedTrustAnchor::from_subject_spki_name_constraints(
         ta.subject,
         ta.spki,
         ta.name_constraints,
       )
-    }),
-  );
+    },
+  ));
 
   let config = ClientConfig::builder()
     .with_safe_defaults()

--- a/examples/tls_client.rs
+++ b/examples/tls_client.rs
@@ -32,15 +32,15 @@ where
 fn tls_connector() -> Result<TlsConnector> {
   let mut root_store = tokio_rustls::rustls::RootCertStore::empty();
 
-  root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(
-    |ta| {
+  root_store.add_server_trust_anchors(
+    webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
       OwnedTrustAnchor::from_subject_spki_name_constraints(
         ta.subject,
         ta.spki,
         ta.name_constraints,
       )
-    },
-  ));
+    }),
+  );
 
   let config = ClientConfig::builder()
     .with_safe_defaults()


### PR DESCRIPTION
Modifications:
1. remove deprecated method `add_server_trust_anchors`
2. append upgrade feature to required examples and tests