### PR TITLE
chore: Update Base64 crate to 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,7 +402,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "criterion",
  "http",
@@ -1041,7 +1047,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ hyper = { version = "1", features = [
     "client",
 ], optional = true }
 pin-project = { version = "1.0.8", optional = true }
-base64 = { version = "0.21.0", optional = true }
+base64 = { version = "0.22.0", optional = true }
 sha1 = { version = "0.10.5", optional = true }
 utf-8 = "0.7.5"
 rand = "0.8.4"


### PR DESCRIPTION
The breaking change did not effect any current usage in `fastwebsockets`, so it just needed a version bump.

Version 0.22 was released over a year ago, and the majority of the eco-system, has already migrated. In our stack, `fastwebsockets` is only crate using the old version.

Thanks.