### PR TITLE
fix: Role::Server doesn't work without auto_apply_mask

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,7 +606,7 @@ impl ReadHalf {
       Err(e) => return (Err(e), None),
     };
 
-    if self.role == Role::Server && self.auto_apply_mask {
+    if self.role == Role::Server {
       frame.unmask()
     };
 


### PR DESCRIPTION
I'm trying to replace `tokio-tungstenite` client with `fastwebsockets` in one of my project, and have to use buffer level `AsyncRead` & `AsyncWrite` instead of message level `Stream` & `Sink`. I'm using `tokio::io::SimplexStream` to accumulate an echo service in the testcases, and I known it's a really **bad** server implementation, but `mask` still surprises me: the mannual `frame.unmask`  call doesn't work with text/binary message due to `Fragments::accumulate`!

* the mask is dropped
* even we keep mask, text message goes `InvalidUTF8` error because of the eager check.

It means the server only work under `auto_apply_mask` in current implementation!

This is the easiest way to be sound. Free free to close this PR, because we may choose to support it, even it's acceptable that we ignore it because it's totally the [server implementation fault](https://www.rfc-editor.org/rfc/rfc6455.html#:~:text=A%20server%20MUST%20NOT%20mask%20any%20frames%20that%20it%20sends%20to%0A%20%20%20the%20client)