### PR TITLE
Remove `simdutf8/aarch64_neon` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ required-features = ["upgrade"]
 
 [dependencies]
 tokio = { version = "1.25.0", default-features = false, features = ["io-util"] }
-simdutf8 = { version = "0.1.4", optional = true }
+simdutf8 = { version = "0.1.5", optional = true }
 hyper-util = { version = "0.1.0", features = ["tokio"], optional = true }
 http-body-util = { version = "0.1.0", optional = true }
 hyper = { version = "1", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,7 @@ http = { version = "1", optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]
-default = ["simd"]
-simd = ["simdutf8/aarch64_neon"]
+default = []
 upgrade = [
     "hyper",
     "pin-project",


### PR DESCRIPTION
This is now enabled by default using Rust std in simdutf8

Closes https://github.com/denoland/fastwebsockets/issues/105