### PR TITLE
perf: optimize buffer handling and fragment gecoding

### DIFF
--- a/src/fragment.rs
+++ b/src/fragment.rs
@@ -225,19 +225,23 @@ impl Fragments {
           return Ok(Some(Frame::new(true, frame.opcode, None, frame.payload)));
         } else {
           self.fragments = match frame.opcode {
-            OpCode::Text => match utf8::decode(&frame.payload) {
-              Ok(text) => Some(Fragment::Text(None, text.as_bytes().to_vec())),
-              Err(utf8::DecodeError::Incomplete {
-                valid_prefix,
-                incomplete_suffix,
-              }) => Some(Fragment::Text(
-                Some(incomplete_suffix),
-                valid_prefix.as_bytes().to_vec(),
-              )),
-              Err(utf8::DecodeError::Invalid { .. }) => {
-                return Err(WebSocketError::InvalidUTF8);
+            OpCode::Text => {
+              let mut buf: Vec<u8> = frame.payload.into();
+              match utf8::decode(&buf) {
+                Ok(_) => Some(Fragment::Text(None, buf)),
+                Err(utf8::DecodeError::Incomplete {
+                  valid_prefix,
+                  incomplete_suffix,
+                }) => {
+                  let valid_len = valid_prefix.len();
+                  buf.truncate(valid_len);
+                  Some(Fragment::Text(Some(incomplete_suffix), buf))
+                }
+                Err(utf8::DecodeError::Invalid { .. }) => {
+                  return Err(WebSocketError::InvalidUTF8);
+                }
               }
-            },
+            }
             OpCode::Binary => Some(Fragment::Binary(frame.payload.into())),
             _ => unreachable!(),
           };

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -334,17 +334,15 @@ impl<'f> Frame<'f> {
 
   /// Writes the frame to the buffer and returns a slice of the buffer containing the frame.
   pub fn write<'a>(&mut self, buf: &'a mut Vec<u8>) -> &'a [u8] {
-    fn reserve_enough(buf: &mut Vec<u8>, len: usize) {
-      if buf.len() < len {
-        buf.resize(len, 0);
-      }
-    }
     let len = self.payload.len();
-    reserve_enough(buf, len + MAX_HEAD_SIZE);
+    buf.clear();
+    buf.reserve(len + MAX_HEAD_SIZE);
 
-    let size = self.fmt_head(buf);
-    buf[size..size + len].copy_from_slice(&self.payload);
-    &buf[..size + len]
+    let mut head = [0u8; MAX_HEAD_SIZE];
+    let size = self.fmt_head(&mut head);
+    buf.extend_from_slice(&head[..size]);
+    buf.extend_from_slice(&self.payload);
+    &buf[..]
   }
 }
 


### PR DESCRIPTION
Improves memory efficiency and reduces CPU overhead in the WebSocket writing and fragment processing logic. Shifted to ownership transfers and in-place mutations and reduced the number of heap allocations and eliminate unnecessary buffer zero-initializations.

Operation | Before this PR| After this PR
-- | -- | --
Write Header | Allocation + Zero-init + Copy | Allocation + Copy
Decode Text | $O(n)$ Copy to new Vec | $O(1)$ Ownership transfer / Truncate