### PR TITLE
Aligning header parsing with RFC 6455

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,14 +714,16 @@ impl ReadHalf {
       None
     };
 
-    if frame::is_control(opcode) && !fin {
-      return Err(WebSocketError::ControlFrameFragmented);
-    }
+    if frame::is_control(opcode) {
+      if !fin {
+        return Err(WebSocketError::ControlFrameFragmented);
+      }
 
-    if opcode == OpCode::Ping && payload_len > 125 {
-      return Err(WebSocketError::PingFrameTooLarge);
+      if payload_len > 125 {
+        return Err(WebSocketError::PingFrameTooLarge);
+      }
     }
-
+      
     if payload_len >= self.max_message_size {
       return Err(WebSocketError::FrameTooLarge);
     }


### PR DESCRIPTION
According to https://www.rfc-editor.org/info/rfc6455/#section-5.5 , the max payload length of 125 not only concerns Ping frames but all control frames.

Note: To properly implement this. The `WebSocketError::PingFrameTooLarge` should be replaced by a `WebSocketError::ControlFrameTooLarge`.